### PR TITLE
fix(webui): unblock CI npm audit (next 15.5.18 + lodash override)

### DIFF
--- a/src/webui/app/package-lock.json
+++ b/src/webui/app/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.475.0",
-        "next": "15.5.10",
+        "next": "15.5.18",
         "patch-package": "^8.0.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -665,9 +665,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.10.tgz",
-      "integrity": "sha512-plg+9A/KoZcTS26fe15LHg+QxReTazrIOoKKUC3Uz4leGGeNPgLHdevVraAAOX0snnUs3WkRx3eUQpj9mreG6A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -3707,9 +3707,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.castarray": {
@@ -4729,12 +4729,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.10.tgz",
-      "integrity": "sha512-r0X65PNwyDDyOrWNKpQoZvOatw7BcsTPRKdwEqtc9cj3wv7mbBIk9tKed4klRaFXJdX0rugpuMTHslDrAU1bBg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.10",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/src/webui/app/package.json
+++ b/src/webui/app/package.json
@@ -43,7 +43,7 @@
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.475.0",
-    "next": "15.5.10",
+    "next": "15.5.18",
     "patch-package": "^8.0.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
@@ -64,5 +64,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "overrides": {
+    "lodash": "^4.17.24"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `next` from `15.5.10` → `15.5.18` (resolves multiple high-severity advisories incl. middleware/proxy bypass, cache poisoning, image-cache DoS, SSRF, etc.)
- Add `overrides.lodash: ^4.17.24` to force the transitive lodash (pulled by `recharts`) to a non-vulnerable version
- Regenerate `package-lock.json`

The deploy workflow's `Security audit` step (`npm audit --audit-level=high` in `src/webui/app`) was failing on these two high vulns and stopping the Azure deploy. After this change, `npm audit --audit-level=high` exits 0 locally (2 moderate findings in postcss-via-next remain, but the CI threshold ignores moderate).

## Test plan
- [ ] CI `Security audit` step passes
- [ ] CI `Build frontend` step still succeeds with next 15.5.18
- [ ] Azure deploy completes