### PR TITLE
rag-ingest workflow: drop pip cache so the secrets-skip path passes

### DIFF
--- a/.github/workflows/rag-ingest.yml
+++ b/.github/workflows/rag-ingest.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "data/rag_docs/**"
       - "scripts/rag_ingest.py"
+      - ".github/workflows/rag-ingest.yml"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -29,7 +30,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: "pip"
+          # No pip cache: its post-job step fails when the install step is
+          # skipped (secrets unset) because ~/.cache/pip never gets created.
 
       - name: Check secrets are configured
         id: secrets_check


### PR DESCRIPTION
## Summary

The graceful skip added in #27 works (the run logs the "secrets not configured" warning and does nothing), but the job still finished red: `actions/setup-python`'s post-job cache step errors with `Cache folder path is retrieved for pip but doesn't exist on disk` because the pip install step was skipped and `~/.cache/pip` never got created.

- Remove `cache: "pip"` from setup-python (saves seconds only; not worth a red run)
- Add the workflow file itself to the `paths` trigger so future workflow edits get validated by an actual run

With this, the ingest workflow goes green-with-warning until the `PINECONE_API_KEY` / `HF_TOKEN` repository secrets are added, and runs for real afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129DQCwdgpZ4fXvhq3YEykw

---
_Generated by [Claude Code](https://claude.ai/code/session_0129DQCwdgpZ4fXvhq3YEykw)_