### PR TITLE
Serialize Azure deploys and verify the live site after each deploy

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -9,6 +9,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Serialize deploys: Azure OneDeploy returns 409 Conflict when two
+# deployments overlap, which happens whenever merges land back-to-back.
+# Queue new runs behind the active one instead of racing it; cancel
+# superseded queued runs so only the newest commit deploys.
+concurrency:
+  group: azure-deploy
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -99,13 +107,33 @@ jobs:
           echo "Checking Azure application logs..."
           az webapp log tail --name ClimateReslianceAPP --resource-group ${{ secrets.AZURE_RESOURCE_GROUP || 'Embeddings' }} --timeout 30 || true
           
-      - name: Health check
+      - name: Health check (live site verification)
         run: |
-          sleep 60  # Wait longer for startup
-          echo "Testing health endpoint..."
-          curl -v https://climatereslianceapp.azurewebsites.net/health || {
-            echo "Health check failed, checking logs again..."
-            az webapp log tail --name ClimateReslianceAPP --resource-group ${{ secrets.AZURE_RESOURCE_GROUP || 'Embeddings' }} --timeout 10 || true
-            exit 1
+          # Poll until the app answers — cold starts after deploy can take a
+          # few minutes (startup command pip-installs requirements).
+          echo "Waiting for the app to come up..."
+          for i in $(seq 1 30); do
+            if curl -sf -m 15 https://climatereslianceapp.azurewebsites.net/health > /tmp/health.json; then
+              echo "✅ /health answered after ~$((i*20))s: $(cat /tmp/health.json)"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "❌ /health never answered (10 min)";
+              az webapp log tail --name ClimateReslianceAPP --resource-group ${{ secrets.AZURE_RESOURCE_GROUP || 'Embeddings' }} --timeout 10 || true
+              exit 1
+            fi
+            sleep 20
+          done
+
+          echo "Verifying the frontend is served..."
+          curl -sf -m 20 https://climatereslianceapp.azurewebsites.net/ | grep -qi "climate" || {
+            echo "❌ Homepage did not serve the frontend"; exit 1;
           }
-          echo "✅ Deployment health check passed"
+          echo "✅ Frontend serving"
+
+          echo "Verifying the custom domain..."
+          curl -sf -m 20 https://climatechat-to.ca/health > /dev/null \
+            && echo "✅ climatechat-to.ca healthy" \
+            || echo "⚠️ climatechat-to.ca not reachable from runner (DNS/binding) — app itself is healthy"
+
+          echo "✅ Deployment verified live"


### PR DESCRIPTION
## Summary

Two deploy runs (from #28 and #29 merging back-to-back) failed with `Conflict (CODE: 409)` — Azure OneDeploy rejects a second deployment while one is in flight. The deploys themselves were fine; they were racing each other.

### Changes

- **`concurrency: azure-deploy`** on the deploy workflow: runs now queue behind the active deploy instead of colliding.
- **Real live-site verification** replaces the single-shot health check:
  - poll `/health` for up to 10 minutes (cold starts pip-install requirements, 60s wasn't reliable)
  - assert the homepage actually serves the frontend
  - check the `climatechat-to.ca` custom domain (warning-only — DNS/domain binding is outside the app's control)

A green "Deploy to Azure App Service" run now *means* the live site answered its health check and served the frontend — the workflow is the live-site monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129DQCwdgpZ4fXvhq3YEykw

---
_Generated by [Claude Code](https://claude.ai/code/session_0129DQCwdgpZ4fXvhq3YEykw)_