### PR TITLE
Widget-fit chat UI (consent page, compact welcome, answer snap-to-top) + embed refinements

### DIFF
--- a/docs/ghost-embed/README.md
+++ b/docs/ghost-embed/README.md
@@ -23,12 +23,30 @@ inside the iframe on the app's own domain. That means:
 - **No secrets in the website** — all API keys stay on the server.
 - **One deployment to maintain** — the widget always shows whatever is live.
 
-## Installation
+## Two embed styles
+
+| Style | File | Where it goes | What visitors see |
+|---|---|---|---|
+| **Floating bubble** (site-wide) | [`ghost-code-injection.html`](ghost-code-injection.html) | Ghost Admin → Settings → Code injection → **Site footer** | A "Chat with Dunia" pill + bubble in the corner of every page; clicking opens the chat panel |
+| **Inline** (one page) | [`ghost-inline-embed.html`](ghost-inline-embed.html) | An **HTML card** inside a specific page or post | The full chat visible immediately on that page — no clicking. Ideal for a dedicated "Chat" page in the site menu |
+
+They can be combined: the bubble site-wide plus a dedicated chat page.
+
+## Installation — floating bubble
 
 1. Open **Ghost Admin → Settings → Code injection**.
 2. Paste the entire contents of [`ghost-code-injection.html`](ghost-code-injection.html)
    into the **Site footer** box.
-3. Click **Save**. The bubble appears in the bottom-right corner of every page.
+3. Click **Save**. The bubble appears in the bottom-right corner of every page,
+   with a "Chat with Dunia" label that hides after the chat is first opened
+   (per browsing session).
+
+## Installation — inline page
+
+1. In Ghost Admin, edit the page (or create one, e.g. "Chat with Dunia").
+2. Add an **HTML card** where the chat should appear and paste the contents of
+   [`ghost-inline-embed.html`](ghost-inline-embed.html) into it.
+3. Publish. The full chat renders right on the page.
 
 The snippet is origin-agnostic: it works the same on
 `climate-resilient-communities.ghost.io` and on any custom domain the site

--- a/docs/ghost-embed/ghost-code-injection.html
+++ b/docs/ghost-embed/ghost-code-injection.html
@@ -40,9 +40,21 @@
     "#dunia-chat-btn:hover { background: " + BRAND_DARK + "; transform: scale(1.06); }",
     "#dunia-chat-btn:focus-visible { outline: 3px solid " + BRAND + "; outline-offset: 3px; }",
     "#dunia-chat-btn svg { width: 28px; height: 28px; display: block; }",
+    /* Two-id selector so this outranks the `#dunia-chat-btn svg` sizing rule */
     "#dunia-chat-root.dunia-open #dunia-chat-icon-chat { display: none; }",
-    "#dunia-chat-icon-close { display: none; }",
+    "#dunia-chat-btn #dunia-chat-icon-close { display: none; }",
     "#dunia-chat-root.dunia-open #dunia-chat-icon-close { display: block; }",
+
+    /* Teaser label next to the bubble (shown until the chat is first opened) */
+    "#dunia-chat-label { position: fixed; right: 92px; bottom: 34px; z-index: 2147483001;",
+    "  border: 1px solid #dbe4e0; background: #fff; color: #0b3d33; cursor: pointer; margin: 0;",
+    "  border-radius: 999px; padding: 9px 14px; font-size: 13px; font-weight: 600; line-height: 1;",
+    "  font-family: inherit; box-shadow: 0 4px 16px rgba(4, 61, 49, 0.18); white-space: nowrap;",
+    "  opacity: 0; transform: translateY(4px); }",
+    "#dunia-chat-label.dunia-label-show { opacity: 1; transform: none; }",
+    "#dunia-chat-label:hover { border-color: " + BRAND + "; }",
+    "#dunia-chat-label:focus-visible { outline: 2px solid " + BRAND + "; outline-offset: 2px; }",
+    "#dunia-chat-root.dunia-open #dunia-chat-label { display: none; }",
 
     /* Panel */
     "#dunia-chat-panel { position: fixed; right: 20px; bottom: 92px; z-index: 2147483001;",
@@ -81,6 +93,7 @@
     "@media (prefers-reduced-motion: no-preference) {",
     "  #dunia-chat-btn { transition: background 0.15s ease, transform 0.15s ease; }",
     "  #dunia-chat-panel { transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s; }",
+    "  #dunia-chat-label { transition: opacity 0.3s ease, transform 0.3s ease; }",
     "}",
 
     /* Small screens: full-screen chat with its own close button */
@@ -128,6 +141,28 @@
     var frame = null;
     var isOpen = false;
 
+    // "Chat with Dunia" pill beside the bubble — makes the entry point
+    // discoverable. It disappears once the chat has been opened and stays
+    // hidden for the rest of the browsing session.
+    var LABEL_SEEN_KEY = "dunia-chat-opened";
+    var label = null;
+    var labelSeen = false;
+    try { labelSeen = window.sessionStorage.getItem(LABEL_SEEN_KEY) === "1"; } catch (e) { /* storage blocked */ }
+    if (!labelSeen) {
+      label = document.createElement("button");
+      label.id = "dunia-chat-label";
+      label.type = "button";
+      label.textContent = BUTTON_LABEL;
+      label.addEventListener("click", function () { open(); });
+      root.appendChild(label);
+      setTimeout(function () { if (label) label.classList.add("dunia-label-show"); }, 700);
+    }
+
+    function dismissLabel() {
+      if (label) { label.remove(); label = null; }
+      try { window.sessionStorage.setItem(LABEL_SEEN_KEY, "1"); } catch (e) { /* storage blocked */ }
+    }
+
     // The iframe is only created on demand, so pages load with zero
     // extra network traffic until a visitor shows interest in the chat.
     function ensureFrame() {
@@ -151,6 +186,7 @@
 
     function open() {
       ensureFrame();
+      dismissLabel();
       isOpen = true;
       root.classList.add("dunia-open");
       btn.setAttribute("aria-expanded", "true");
@@ -171,9 +207,10 @@
     });
 
     // Warm up the App Service as soon as the visitor hovers or focuses
-    // the bubble, so the chat is usually ready by the time they click.
+    // the bubble or label, so the chat is usually ready by the time they click.
     ["mouseenter", "focus", "touchstart"].forEach(function (evt) {
       btn.addEventListener(evt, ensureFrame, { passive: true });
+      if (label) label.addEventListener(evt, ensureFrame, { passive: true });
     });
   }
 

--- a/docs/ghost-embed/ghost-inline-embed.html
+++ b/docs/ghost-embed/ghost-inline-embed.html
@@ -1,0 +1,26 @@
+<!-- ============================================================
+  Dunia inline embed — the full chat visible directly on a page
+
+  Use this instead of (or alongside) the floating bubble when the
+  chat should be immediately visible with no clicking — e.g. on a
+  dedicated "Chat with Dunia" page linked from the site menu.
+
+  In Ghost: edit the page or post, add an **HTML card** where the
+  chat should appear, and paste this whole block into it.
+
+  Tweaks:
+  - Height: min(78vh, 720px) fills most of the screen, capped at
+    720px. Raise or lower to taste; min-height keeps it usable on
+    small screens.
+  - URL: if the custom domain is ever unavailable, switch the
+    iframe src to https://climatereslianceapp.azurewebsites.net/
+============================================================ -->
+<div style="position: relative; width: 100%; height: min(78vh, 720px); min-height: 480px; border: 1px solid #dbe4e0; border-radius: 16px; overflow: hidden; box-shadow: 0 8px 32px rgba(0, 0, 0, 0.10); background: #f7f9fc;">
+  <iframe
+    src="https://climatechat-to.ca/"
+    title="Dunia · Climate Chat"
+    style="position: absolute; inset: 0; width: 100%; height: 100%; border: 0;"
+    allow="clipboard-write; fullscreen"
+    loading="lazy"
+  ></iframe>
+</div>

--- a/src/webui/app/src/app/components/chat/sample-questions.tsx
+++ b/src/webui/app/src/app/components/chat/sample-questions.tsx
@@ -22,7 +22,7 @@ export function SampleQuestions({ onQuestionClick }: SampleQuestionsProps) {
                 <button
                     key={text}
                     type="button"
-                    className="group flex items-center gap-3 rounded-xl border bg-card/80 px-4 py-3 text-left text-sm text-foreground shadow-sm transition-colors hover:border-primary/40 hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    className="group flex items-center gap-2.5 rounded-xl border bg-card/80 px-3.5 py-2.5 text-left text-[13px] text-foreground shadow-sm transition-colors hover:border-primary/40 hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     onClick={() => onQuestionClick(text)}
                 >
                     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">

--- a/src/webui/app/src/app/page.tsx
+++ b/src/webui/app/src/app/page.tsx
@@ -9,7 +9,7 @@ import Textarea from 'react-textarea-autosize';
 import { ArrowUp, Square } from "lucide-react";
 import { AppHeader } from "@/app/components/chat/app-header";
 import { ChatWindow } from "@/components/chat/chat-window";
-import { ConsentDialog } from "@/components/chat/consent-dialog";
+import { ConsentPage } from "@/components/chat/consent-page";
 import { type Message } from "@/components/chat/chat-message";
 import { type Source } from "@/components/chat/citations-popover";
 import { apiClient, type ChatRequest, type CitationDict, type LanguageDetectionRequest } from "@/lib/api";
@@ -318,7 +318,7 @@ export default function Home() {
   }
 
   if (showConsent) {
-    return <ConsentDialog open={showConsent} onConsent={handleConsent} />;
+    return <ConsentPage onConsent={handleConsent} />;
   }
 
   const canSend = inputValue.trim().length > 0 && !isStreaming;
@@ -360,7 +360,7 @@ export default function Home() {
               }}
               placeholder="Ask about climate change…"
               aria-label="Ask about climate change"
-              className="max-h-40 min-h-0 flex-1 resize-none border-0 bg-transparent px-0 py-2 text-[15px] shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="max-h-40 min-h-0 flex-1 resize-none border-0 bg-transparent px-0 py-2 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
               minRows={1}
               maxRows={6}
               as={Textarea}

--- a/src/webui/app/src/components/chat/chat-message.tsx
+++ b/src/webui/app/src/components/chat/chat-message.tsx
@@ -151,7 +151,7 @@ export function ChatMessage({ message, onRetry }: ChatMessageProps) {
   if (isUser) {
     return (
       <div className="flex justify-end">
-        <div className="message-bubble max-w-[85%] whitespace-pre-wrap break-words rounded-2xl rounded-br-md bg-primary px-4 py-2.5 text-[15px] leading-relaxed text-primary-foreground shadow-sm">
+        <div className="message-bubble max-w-[85%] whitespace-pre-wrap break-words rounded-2xl rounded-br-md bg-primary px-3.5 py-2 text-sm leading-relaxed text-primary-foreground shadow-sm">
           {message.content}
         </div>
       </div>
@@ -181,28 +181,28 @@ export function ChatMessage({ message, onRetry }: ChatMessageProps) {
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={{
-                    h1: ({node, ...props}) => <h1 className="mb-2 mt-4 text-xl font-semibold tracking-tight text-foreground first:mt-0" {...props} />,
-                    h2: ({node, ...props}) => <h2 className="mb-2 mt-4 text-lg font-semibold tracking-tight text-foreground first:mt-0" {...props} />,
-                    h3: ({node, ...props}) => <h3 className="mb-1.5 mt-3 text-[15px] font-semibold text-foreground first:mt-0" {...props} />,
-                    p: ({node, ...props}) => <p className="mb-2.5 text-[15px] leading-7 text-foreground last:mb-0" {...props} />,
-                    ul: ({node, ...props}) => <ul className="mb-2.5 list-disc space-y-1 pl-5 text-[15px] leading-7 text-foreground marker:text-primary/60 last:mb-0" {...props} />,
-                    ol: ({node, ...props}) => <ol className="mb-2.5 list-decimal space-y-1 pl-5 text-[15px] leading-7 text-foreground marker:font-medium marker:text-muted-foreground last:mb-0" {...props} />,
+                    h1: ({node, ...props}) => <h1 className="mb-2 mt-4 text-lg font-semibold tracking-tight text-foreground first:mt-0" {...props} />,
+                    h2: ({node, ...props}) => <h2 className="mb-2 mt-3.5 text-base font-semibold tracking-tight text-foreground first:mt-0" {...props} />,
+                    h3: ({node, ...props}) => <h3 className="mb-1.5 mt-3 text-sm font-semibold text-foreground first:mt-0" {...props} />,
+                    p: ({node, ...props}) => <p className="mb-2.5 text-sm leading-6 text-foreground last:mb-0" {...props} />,
+                    ul: ({node, ...props}) => <ul className="mb-2.5 list-disc space-y-1 pl-5 text-sm leading-6 text-foreground marker:text-primary/60 last:mb-0" {...props} />,
+                    ol: ({node, ...props}) => <ol className="mb-2.5 list-decimal space-y-1 pl-5 text-sm leading-6 text-foreground marker:font-medium marker:text-muted-foreground last:mb-0" {...props} />,
                     li: ({node, ...props}) => <li className="pl-1 [&>p]:mb-1" {...props} />,
                     strong: ({node, ...props}) => <strong className="font-semibold text-foreground" {...props} />,
                     em: ({node, ...props}) => <em className="italic" {...props} />,
                     table: ({node, ...props}) => (
                         <div className="my-3 overflow-x-auto rounded-lg border">
-                            <table className="w-full border-collapse text-sm [&_tr:last-child_td]:border-b-0" {...props} />
+                            <table className="w-full border-collapse text-[13px] [&_tr:last-child_td]:border-b-0" {...props} />
                         </div>
                     ),
                     thead: ({node, ...props}) => <thead className="bg-muted/60" {...props} />,
-                    th: ({node, ...props}) => <th className="border-b px-3 py-2 text-left text-[13px] font-semibold text-foreground" {...props} />,
-                    td: ({node, ...props}) => <td className="border-b border-border/70 px-3 py-2 align-top text-foreground" {...props} />,
+                    th: ({node, ...props}) => <th className="border-b px-3 py-1.5 text-left text-xs font-semibold text-foreground" {...props} />,
+                    td: ({node, ...props}) => <td className="border-b border-border/70 px-3 py-1.5 align-top text-foreground" {...props} />,
                     code: ({node, ...props}: any) => {
                         const inline = !props.className?.includes('language-');
                         return inline
-                            ? <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[13px] text-foreground" {...props} />
-                            : <code className="my-2 block overflow-x-auto rounded-lg bg-muted p-3 font-mono text-[13px] text-foreground" {...props} />;
+                            ? <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground" {...props} />
+                            : <code className="my-2 block overflow-x-auto rounded-lg bg-muted p-3 font-mono text-xs text-foreground" {...props} />;
                     },
                     blockquote: ({node, ...props}) => <blockquote className="my-2 border-l-2 border-primary/40 pl-3 italic text-muted-foreground" {...props} />,
                     hr: ({node, ...props}) => <hr className="my-3 border-border" {...props} />,

--- a/src/webui/app/src/components/chat/chat-window.tsx
+++ b/src/webui/app/src/components/chat/chat-window.tsx
@@ -23,17 +23,38 @@ export function ChatWindow({ messages, isStreaming, onQuestionClick, onRetry }: 
   const containerRef = useRef<HTMLDivElement>(null);
   const atBottomRef = useRef(true);
   const prevCountRef = useRef(0);
+  const streamingByIdRef = useRef<Map<string, boolean>>(new Map());
   const [showJump, setShowJump] = useState(false);
 
   // Auto-follow rules: a new message always scrolls into view; streamed
   // content only keeps the view pinned while the reader is already at the
-  // bottom — scrolling up to read is never interrupted.
+  // bottom; and when an answer finishes, the view jumps back to the TOP of
+  // that answer so it can be read from the beginning.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
+    // Detect an assistant message transitioning streaming -> done
+    let completedId: string | null = null;
+    for (const m of messages) {
+      if (m.role === "assistant" && m.id) {
+        if (streamingByIdRef.current.get(m.id) && !m.streaming) completedId = m.id;
+        streamingByIdRef.current.set(m.id, !!m.streaming);
+      }
+    }
+
     const isNewMessage = messages.length !== prevCountRef.current;
     prevCountRef.current = messages.length;
+
+    if (completedId) {
+      const el = container.querySelector<HTMLElement>(`[data-msg-id="${CSS.escape(completedId)}"]`);
+      if (el) {
+        const top = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+        container.scrollTop = Math.max(0, top - 8);
+        atBottomRef.current = false;
+        return; // don't pin to bottom on the completion update
+      }
+    }
 
     if (isNewMessage || atBottomRef.current) {
       container.scrollTop = container.scrollHeight;
@@ -74,20 +95,21 @@ export function ChatWindow({ messages, isStreaming, onQuestionClick, onRetry }: 
       >
         <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6">
           {messages.length === 0 ? (
-            <div className="flex flex-col items-center pt-10 text-center md:pt-24">
-              <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 ring-1 ring-primary/15">
-                <Image src={Logo} alt="Dunia logo" width={40} height={40} className="h-10 w-10" />
+            <div className="flex flex-col items-center pt-1 text-center sm:pt-4">
+              <div className="flex items-center justify-center gap-2.5">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/15">
+                  <Image src={Logo} alt="Dunia logo" width={26} height={26} className="h-[26px] w-[26px]" />
+                </div>
+                <h1 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+                  Welcome to Dunia
+                </h1>
               </div>
-              <h1 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
-                Welcome to Dunia
-              </h1>
-              <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground md:text-[15px] md:leading-7">
-                Dunia means &ldquo;world&rdquo; in Swahili — and I can chat in many of the
-                world&rsquo;s languages. Pick yours from the menu above or just start typing.
-                I answer with verified information and local resources, always with sources.
+              <p className="mt-2.5 max-w-md text-[13px] leading-5 text-muted-foreground">
+                Dunia means &ldquo;world&rdquo; in Swahili. Ask me about climate change in any
+                language — every answer comes with verified sources.
               </p>
-              <div className="mt-10 w-full">
-                <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              <div className="mt-5 w-full">
+                <p className="mb-2.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                   Try asking
                 </p>
                 <SampleQuestions onQuestionClick={onQuestionClick} />
@@ -96,15 +118,16 @@ export function ChatWindow({ messages, isStreaming, onQuestionClick, onRetry }: 
           ) : (
             <div className="space-y-6">
               {messages.map((msg, index) => (
-                <ChatMessage
-                  key={msg.id || index}
-                  message={msg}
-                  onRetry={
-                    msg.role === "assistant" && onRetry && index === lastAssistantIndex && !isStreaming
-                      ? () => onRetry(index)
-                      : undefined
-                  }
-                />
+                <div key={msg.id || index} data-msg-id={msg.id}>
+                  <ChatMessage
+                    message={msg}
+                    onRetry={
+                      msg.role === "assistant" && onRetry && index === lastAssistantIndex && !isStreaming
+                        ? () => onRetry(index)
+                        : undefined
+                    }
+                  />
+                </div>
               ))}
             </div>
           )}

--- a/src/webui/app/src/components/chat/consent-page.tsx
+++ b/src/webui/app/src/components/chat/consent-page.tsx
@@ -4,51 +4,46 @@
 import { useState } from "react";
 import Image from "next/image";
 import Logo from "@/app/Logo.png";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
 
-type ConsentDialogProps = {
-  open: boolean;
+type ConsentPageProps = {
   onConsent: () => void;
 };
 
-export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
+/**
+ * Consent rendered as a normal page (not a modal): the content scrolls from
+ * the top and fits whatever box the app lives in — including the small
+ * website-embed iframe — while the accept button stays pinned and visible.
+ */
+export function ConsentPage({ onConsent }: ConsentPageProps) {
   const [agreed, setAgreed] = useState(false);
 
   return (
-    <Dialog open={open}>
-      <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-lg" onInteractOutside={(e) => e.preventDefault()}>
-        <DialogHeader className="space-y-2">
-            <div className="flex justify-center">
-                <Image src={Logo} alt="Logo" width={48} height={48} className="w-12 h-12" />
-            </div>
-          <DialogTitle className="text-center text-xl font-bold text-primary !mt-2">Dunia Climate Chatbot</DialogTitle>
-          <DialogDescription className="text-center text-muted-foreground !mt-1">
-            Connecting Communities to Climate Knowledge
-          </DialogDescription>
-          <p className="text-center text-xs text-muted-foreground italic !mt-1">
-            Dunia — Swahili for &ldquo;world&rdquo; — is made by Sprout™
-          </p>
-        </DialogHeader>
-        
-        <div className="flex justify-center py-2">
+    <div className="flex h-[100svh] flex-col bg-background">
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div className="mx-auto w-full max-w-lg px-4 pb-6 pt-6 sm:px-6 sm:pt-8">
+          <div className="flex flex-col items-center text-center">
+            <Image src={Logo} alt="Logo" width={44} height={44} className="h-11 w-11" />
+            <h1 className="mt-2 text-lg font-bold text-primary sm:text-xl">Dunia Climate Chatbot</h1>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              Connecting Communities to Climate Knowledge
+            </p>
+            <p className="mt-1 text-xs italic text-muted-foreground">
+              Dunia — Swahili for &ldquo;world&rdquo; — is made by Sprout™
+            </p>
+          </div>
+
+          <div className="flex justify-center py-3">
             <Separator className="w-1/2" />
-        </div>
-        
-        <div className="space-y-3 text-xs">
+          </div>
+
+          <div className="space-y-3 text-xs">
             <p className="text-center text-muted-foreground">
-              Welcome! This app shares clear info on climate impacts and local action. Please confirm you're good with the basics below.
+              Welcome! This app shares clear info on climate impacts and local action. Please confirm you&rsquo;re good with the basics below.
             </p>
 
             <div className="flex items-start space-x-3 pt-2">
@@ -65,13 +60,12 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
                 <li>I read and agree to the <span className="font-bold">Terms of Use</span></li>
                 <li>I read and understand the <span className="font-bold">Disclaimer</span></li>
             </ul>
-        </div>
+          </div>
 
-
-        <Accordion type="single" collapsible className="w-full text-xs">
+          <Accordion type="single" collapsible className="mt-2 w-full text-xs">
           <AccordionItem value="privacy">
             <AccordionTrigger className="text-xs">Privacy Policy</AccordionTrigger>
-            <AccordionContent className="max-h-48 overflow-y-auto pr-4">
+            <AccordionContent>
               <div className="text-xs text-muted-foreground space-y-3">
                 <p><strong>Privacy Policy</strong><br />Last Updated: January 28, 2025</p>
 
@@ -90,7 +84,7 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
                         <li>Usage patterns</li>
                     </ul>
                 </div>
-                
+
                 <div className="space-y-1 pl-4">
                     <h5 className="font-semibold text-foreground">What We Do Collect</h5>
                     <ul className="list-disc list-outside space-y-1 pl-5">
@@ -120,7 +114,7 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
                         <li>Limited access controls</li>
                     </ul>
                 </div>
-                
+
                 <div className="space-y-1">
                     <h4 className="font-semibold text-foreground">Third-Party Services</h4>
                     <p>Our chatbot utilizes Cohere's language models. Users should note:</p>
@@ -145,7 +139,7 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
           </AccordionItem>
           <AccordionItem value="terms">
             <AccordionTrigger className="text-xs">Terms of Use</AccordionTrigger>
-            <AccordionContent className="max-h-48 overflow-y-auto pr-4">
+            <AccordionContent>
               <div className="text-xs text-muted-foreground space-y-3">
                 <p><strong>Terms of Use</strong><br />Last Updated: January 28, 2025</p>
 
@@ -191,7 +185,7 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
                     <li>Documentation and supporting materials</li>
                   </ul>
                 </div>
-                
+
                 <div className="space-y-1">
                   <h4 className="font-semibold text-foreground">Liability Limitation</h4>
                   <p>The chatbot and its services are provided "as is" and "as available" without any warranties, expressed or implied. Sprout is not liable for any damages arising from:</p>
@@ -207,7 +201,7 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
           </AccordionItem>
           <AccordionItem value="disclaimer">
             <AccordionTrigger className="text-xs">Disclaimer</AccordionTrigger>
-            <AccordionContent className="max-h-48 overflow-y-auto pr-4">
+            <AccordionContent>
                 <div className="text-xs text-muted-foreground space-y-3">
                     <p><strong>Disclaimer</strong><br />Last Updated: January 28, 2025</p>
 
@@ -230,7 +224,7 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
                             <li>Consult local authorities for community-specific guidance</li>
                         </ul>
                     </div>
-                    
+
                     <div className="space-y-1">
                         <h4 className="font-semibold text-foreground">Third-Party Content</h4>
                         <p>Citations and references to third-party content are provided for transparency and verification. Sprout does not endorse and is not responsible for the accuracy, completeness, or reliability of third-party information.</p>
@@ -238,14 +232,17 @@ export function ConsentDialog({ open, onConsent }: ConsentDialogProps) {
                 </div>
             </AccordionContent>
           </AccordionItem>
-        </Accordion>
+          </Accordion>
+        </div>
+      </div>
 
-        <DialogFooter className="sm:justify-center mt-2">
+      <div className="shrink-0 border-t bg-background p-3 sm:p-4">
+        <div className="mx-auto w-full max-w-lg">
           <Button type="button" className="w-full" disabled={!agreed} onClick={onConsent}>
             Start Chatting Now
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up round based on testing the chat inside the website embed widget:

### Chat UI fixes (affects the deployed app)
- **Consent as a normal page, not a modal**: content starts at the top and scrolls within whatever box the app lives in; the "Start Chatting Now" button is pinned and always visible. The old modal overflowed the small embed panel and cut off its own accept button. (`consent-dialog.tsx` → `consent-page.tsx`)
- **Compact, top-aligned welcome**: small icon + title on one row with a one-line subtitle, so all sample questions fit inside the 400px embed panel.
- **Answer snap-to-top**: when a response finishes generating, the view scrolls back to the top of that response so it reads from the beginning; the jump-to-latest button remains available.
- **Type scale down one notch** across messages, headings, tables, code, composer, and sample chips to fit the widget panel.

### Ghost embed refinements (docs/snippets only)
- "Chat with Dunia" label pill beside the bubble, hidden for the rest of the session once the chat is opened.
- Fix a CSS specificity bug where the closed bubble showed both the chat icon and the X at once.
- New `ghost-inline-embed.html`: HTML-card snippet that renders the full chat directly on a page (for a dedicated "Chat" page) — no bubble, no clicking.
- README documents both embed styles.

## Test plan

- Playwright at the widget's 400×640 panel size and 390×844 mobile: consent renders with no dialog overlay, starts at scroll top, CTA visible without scrolling; finished answers land within 8px of the top of the response with the title visible; jump-to-latest appears (12/12 checks)
- Embed snippet checks: label shows/opens/stays hidden per session, single icon in closed state, inline iframe renders (7/7 checks)
- `tsc --noEmit` clean; `next build` (lint + static export) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3cAZ6pSBoHxxs5RX4BzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo3cAZ6pSBoHxxs5RX4BzX)_