### PR TITLE
Consent copy: say "Dunia" instead of "This app"

### DIFF
--- a/src/webui/app/src/components/chat/consent-page.tsx
+++ b/src/webui/app/src/components/chat/consent-page.tsx
@@ -43,7 +43,7 @@ export function ConsentPage({ onConsent }: ConsentPageProps) {
 
           <div className="space-y-3 text-xs">
             <p className="text-center text-muted-foreground">
-              Welcome! This app shares clear info on climate impacts and local action. Please confirm you&rsquo;re good with the basics below.
+              Welcome! Dunia shares clear info on climate impacts and local action. Please confirm you&rsquo;re good with the basics below.
             </p>
 
             <div className="flex items-start space-x-3 pt-2">


### PR DESCRIPTION
## Summary

One-line copy fix on the consent page: "Welcome! This app shares clear info…" → "Welcome! Dunia shares clear info…". The chat is embedded on the website, so "This app" read wrong there; "Dunia" matches the "Dunia Climate Chatbot" title directly above it. This is the only user-visible "this app" occurrence in the frontend.

## Test plan

- String-only change in `consent-page.tsx`; grep confirms no other visible "this app" copy remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3cAZ6pSBoHxxs5RX4BzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo3cAZ6pSBoHxxs5RX4BzX)_