### PR TITLE
QA: exercise the real community-demotion stage and cover city-wide queries

### DIFF
--- a/tests/qa/boundary_fakes.py
+++ b/tests/qa/boundary_fakes.py
@@ -133,7 +133,9 @@ def _load_fixture_docs():
 FIXTURE_DOCS = _load_fixture_docs()
 
 
-def _score_docs(query: str):
+def _score_docs(query: str, k: int = 5):
+    """Keyword-score fixture docs; k=None returns every match (the caller
+    mirrors production by demoting community docs before cutting)."""
     q_tokens = set(re.findall(r"[a-z]{3,}", (query or "").lower()))
     scored = []
     for d in FIXTURE_DOCS:
@@ -142,7 +144,7 @@ def _score_docs(query: str):
         if score > 0:
             scored.append(({**d, "score": float(score)}, score))
     scored.sort(key=lambda x: -x[1])
-    top = [d for d, _ in scored[:5]]
+    top = [d for d, _ in (scored if k is None else scored[:k])]
     return top or [dict(FIXTURE_DOCS[-3])]  # general overview fallback
 
 
@@ -432,7 +434,12 @@ class FakeCache:
 
 
 async def fake_get_documents(query, index, embed_model, cohere_client):
-    docs = _score_docs(query)
+    # Mirror production ordering: overfetch every keyword match, run the REAL
+    # community-demotion stage from src.models.retrieval, then cut — so
+    # keyless QA exercises the same doc mix the live retriever produces.
+    from src.models.retrieval import _demote_unrequested_community_docs
+    docs = _score_docs(query, k=None)
+    docs = _demote_unrequested_community_docs(query, docs)[:5]
     _audit("retrieval", query=(query or "")[:120], returned=[d["title"] for d in docs])
     return docs
 

--- a/tests/qa/run_api_qa.py
+++ b/tests/qa/run_api_qa.py
@@ -317,6 +317,24 @@ def s_community_rag():
         "no Thorncliffe citation in response"
 
 
+@scenario("City-wide question → general docs lead, one community doesn't dominate")
+def s_citywide_not_community_dominated():
+    t0 = time.time()
+    status, body = chat("What are the impacts of climate change in Toronto?", language="en", skip_cache=True)
+    assert status == 200, f"status {status}: {body}"
+    retrieved = [e for e in _audit_since(t0) if e.get("kind") == "retrieval"]
+    assert retrieved, "no retrieval performed"
+    returned = retrieved[-1].get("returned", [])
+    assert returned, "retrieval returned nothing"
+    # The context slots must be led by city-general docs, not one community's
+    assert "Thorncliffe" not in returned[0], f"community doc leads city-wide retrieval: {returned}"
+    top3_community = sum(1 for t in returned[:3] if "Thorncliffe" in t)
+    assert top3_community <= 1, f"community docs dominate top-3 for a city-wide question: {returned[:3]}"
+    citations = [c.get("title") or "" for c in body.get("citations", [])]
+    assert citations and "Thorncliffe" not in citations[0], \
+        f"first citation is a community doc for a city-wide question: {citations}"
+
+
 @scenario("SSE streaming endpoint: tokens preserve whitespace, complete event matches contract")
 def s_streaming():
     req = urllib.request.Request(
@@ -359,7 +377,7 @@ def main():
                s_explicit_french, s_chinese_selected, s_mismatch_not_blocked, s_spanish_native,
                s_region_variant, s_greeting, s_offtopic, s_instruction, s_cache, s_followup,
                s_short_query, s_location_followup, s_location_in_query, s_short_query_spanish,
-               s_injection, s_community_rag, s_streaming]:
+               s_injection, s_community_rag, s_citywide_not_community_dominated, s_streaming]:
         fn()
 
     passed = sum(1 for _, s, _ in RESULTS if s == "PASS")


### PR DESCRIPTION
## Summary

Test-only follow-up to #37. The keyless QA harness replaced `get_documents` wholesale, so the community-demotion stage was invisible to end-to-end QA:

- `fake_get_documents` now overfetches every keyword match and runs the **real** `_demote_unrequested_community_docs` before cutting to five docs, mirroring production ordering.
- New scenario **"City-wide question → general docs lead, one community doesn't dominate"**: for a general Toronto question, the first retrieved doc and first citation must not be community-scoped, and community docs may hold at most one of the top-3 context slots.
- Verified the scenario discriminates: the pre-#37 ordering fails it (a Thorncliffe doc led retrieval for a city-wide question); the current ordering passes with zero community docs in the top 3.

## Test plan

- Full keyless API QA matrix against `tests.qa.run_server`: **23/23 scenarios pass**, including the existing location-clarification, community-question (Thorncliffe docs still served when asked for), streaming, language, cache, and guard regressions
- No runtime code changed — `tests/qa/` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo3cAZ6pSBoHxxs5RX4BzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo3cAZ6pSBoHxxs5RX4BzX)_